### PR TITLE
The first frames of output must respect the given speed, too

### DIFF
--- a/src/renderer/renderer.es6
+++ b/src/renderer/renderer.es6
@@ -209,7 +209,7 @@ export default function Renderer(phonemes, pitch, mouth, throat, speed, singmode
       return mem66;
     };
 
-    let speedcounter = 72;
+    let speedcounter = speed;
     let phase1 = 0;
     let phase2 = 0;
     let phase3 = 0;


### PR DESCRIPTION
Before this fix, speed only affected the output starting from the
72nd frame or the first sampled consonant. This didn't make sense.

The same bug is present in the original C source, and quite probably
in the original C64 binary as well.