### PR TITLE
Adds TypeScript type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": false,
   "main": "dist/samjs.min.js",
   "module": "dist/samjs.esm.min.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "dev": "rollup -w -c build/config.js --environment TARGET:dev",
     "dev:cjs": "rollup -w -c build/config.js --environment TARGET:cjs",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,25 @@
+interface SamJsOptions {
+  phonetic?: boolean;
+  singmode?: boolean;
+  debug?: boolean;
+  pitch?: number;
+  speed?: number;
+  mouth?: number;
+  throat?: number;
+}
+
+interface SamJsSpeakPromise extends Promise<true> {
+  abort: (reason: any) => void;
+}
+
+declare class SamJs {
+  constructor(options?: SamJsOptions);
+  buf8(text: string, phonetic?: boolean): Uint8Array | Boolean;
+  buf32(text: string, phonetic?: boolean): Float32Array | Boolean;
+  speak(text: string, phonetic?: boolean): SamJsSpeakPromise;
+  download(text: string, phonetic?: boolean): void;
+}
+
+declare module "sam-js" {
+  export = SamJs;
+}


### PR DESCRIPTION
I tried to see if this could be auto-generated using https://www.typescriptlang.org/tsconfig#emitDeclarationOnly. But it seems that TypeScript has had a long-standing open issue (https://github.com/microsoft/TypeScript/issues/15416) about supporting files not ending in `JS/JSX/TS/TSX`.

Thoughts on adding this? I wasn't sure if this would need any changes to `build/build.js`, but probably not?

If we don't add it here, I would be happy to instead submit a PR to https://github.com/DefinitelyTyped/DefinitelyTyped.